### PR TITLE
build standalone image for linux/arm/v6

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: standalone.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           tags: |
             santam/wms-mqtt:latest


### PR DESCRIPTION
build the standalone docker image for linux/arm/v6.

Background: I had a old Raspberry Zero lying around that I wanted to use with the standalone image.
My actual Home-Assistant server was too far away to reach all blinds so I needed something small to place closer to the blinds.

The Raspberry Zero used armv6 so non of the current docker image work. I have tested a armv6 build and everything seems to work fine.

This PR would just also build a armv6 version for anybody else that might need it for old hardware.